### PR TITLE
fix : 유저정보 중복 확인 쿼리 수정

### DIFF
--- a/src/main/java/com/yht/exerciseassist/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/yht/exerciseassist/domain/member/repository/MemberRepository.java
@@ -2,16 +2,21 @@ package com.yht.exerciseassist.domain.member.repository;
 
 import com.yht.exerciseassist.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query(value = "select m from Member m where m.loginId = :loginId and m.dateTime.canceledAt = null")
     Optional<Member> findByLoginId(String loginId);
 
+    @Query(value = "select m from Member m where m.email = :email and m.dateTime.canceledAt = null")
     Optional<Member> findByEmail(String email);
 
+    @Query(value = "select m from Member m where m.username = :username and m.dateTime.canceledAt = null")
     Optional<Member> findByUsername(String username);
 
+    @Query(value = "select m from Member m where m.refreshToken = :refreshToken and m.dateTime.canceledAt = null")
     Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/yht/exerciseassist/jwt/SecurityUtil.java
+++ b/src/main/java/com/yht/exerciseassist/jwt/SecurityUtil.java
@@ -11,4 +11,13 @@ public class SecurityUtil {
         }
         return authentication.getName();
     }
+
+    public static String getMemberRole() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getAuthorities() == null) {
+            throw new IllegalArgumentException("No authentication information.");
+        }
+        String userRole = authentication.getAuthorities().toString();
+        return userRole.substring(userRole.indexOf("_") + 1, userRole.length() - 1);
+    }
 }


### PR DESCRIPTION

회원가입 시 유저정보 중복 확인 쿼리 탈퇴한 사람의 정보는 비교 대상에서 제외되도록 수정 & accessToken에서 유저 정보 추출 할 수 있는 메서드 생성